### PR TITLE
add support for dynamic custom alerts for services and cronjobs

### DIFF
--- a/k8s/gcp/namespace/deployment.tf
+++ b/k8s/gcp/namespace/deployment.tf
@@ -97,6 +97,6 @@ module "service_deployment" {
   infra_alerts     = each.value.helm_configs != null ? (each.value.helm_configs.infra_alerts != null ? each.value.helm_configs.infra_alerts : null ) : null
   service_random_string = random_string.service_account_name[each.key].result
   command = each.value.helm_configs != null ? (each.value.helm_configs.command != null ? each.value.helm_configs.command : null ) : null
-
+  custom_alerts = each.value.helm_configs != null && contains(keys(each.value.helm_configs), "custom_alerts") && each.value.helm_configs.custom_alerts != null ? each.value.helm_configs.custom_alerts : []
   depends_on = [module.sql_db, module.sql_db_v2 , module.local_redis]
 }

--- a/k8s/gcp/namespace/vars.tf
+++ b/k8s/gcp/namespace/vars.tf
@@ -138,6 +138,18 @@ variable "services" {
         memory_utilisation_threshold   = optional(number)
         cpu_utilisation_threshold      = optional(number)
       }))
+      custom_alerts = optional(list(object({
+        name          = string
+        description   = string
+        alertRule     = string
+        sumByLabel    = optional(string)
+        percentile    = optional(number)
+        labelValue    = optional(string)
+        queryOperator = optional(string)
+        timeWindow    = optional(string)
+        threshold     = number
+        labels        = optional(map(string))
+      })))
     }))
   }))
   default     = {}

--- a/zop-helm/service/main.tf
+++ b/zop-helm/service/main.tf
@@ -63,5 +63,6 @@ resource "helm_release" "service_helm"{
     db_ssl_enabled                  = var.db_ssl_enabled
     pub_sub                         = var.pub_sub
     service_random_string           = var.service_random_string
+    custom_alerts                   = jsonencode(var.custom_alerts)
   })]
 }

--- a/zop-helm/service/templates/values.yaml
+++ b/zop-helm/service/templates/values.yaml
@@ -173,3 +173,22 @@ alerts:
       serviceCpuUtilizationThreshold: ${infra_alerts.cpu_utilisation_threshold}
       %{~ endif ~}
   %{~ endif ~}
+  %{~ if length(jsondecode(custom_alerts)) > 0 ~}
+  custom:
+  %{~ for alert in jsondecode(custom_alerts) ~}
+    - name: "${alert.name}"
+      description: "${alert.description}"
+      alertRule: "${alert.alertRule}"
+      sumByLabel: "${alert.sumByLabel}"
+      percentile: ${alert.percentile}
+      labelValue: "${alert.labelValue}"
+      queryOperator: "${alert.queryOperator}"
+      timeWindow: "${alert.timeWindow}"
+      threshold: ${alert.threshold}
+      labels:
+        %{~ for k, v in alert.labels ~}
+        ${k}: "${v}"
+        %{~ endfor ~}
+  %{~ endfor ~}
+ %{~ else ~}
+%{~ endif ~}

--- a/zop-helm/service/vars.tf
+++ b/zop-helm/service/vars.tf
@@ -247,3 +247,19 @@ variable "service_random_string" {
   type = string
   default = ""
 }
+variable "custom_alerts" {
+  description = "List of custom alerts"
+  type = list(object({
+    name         = string
+    description  = string
+    alertRule    = string
+    sumByLabel   = string
+    percentile   = number
+    labelValue   = string
+    queryOperator = string
+    timeWindow   = string
+    threshold    = number
+    labels       = map(string)
+  }))
+  default = []
+}


### PR DESCRIPTION
Introduced a new custom_alerts variable in vars.tf to define alert rules.

Passed custom_alerts through main.tf and values.yaml into the Helm templates.

Updated the k8s_namespace module to accept alert configuration.

Ensured values are propagated into deployment.tf for alert rule injection.

Cleaned up hardcoded alert logic and made it environment-configurable.