### PR TITLE
added the caching for the mimir in gcp and tuned the values for mimir

### DIFF
--- a/observability/gcp/mimir.tf
+++ b/observability/gcp/mimir.tf
@@ -44,19 +44,20 @@ resource "kubernetes_secret" "mimir-google-credentials" {
 }
 
 data "template_file" "mimir_template" {
-  count = local.enable_mimir ? 1 : 0
+  count    = local.enable_mimir ? 1 : 0
   template = file("${path.module}/templates/mimir-values.yaml")
+
   vars = {
     data_bucket_name                            = google_storage_bucket.mimir_data[0].id
     cluster_name                                = local.cluster_name
     limits_ingestion_rate                       = try(var.mimir.limits.ingestion_rate != null ? var.mimir.limits.ingestion_rate : "500000", "500000")
     limits_ingestion_burst_size                 = try(var.mimir.limits.ingestion_burst_size != null ? var.mimir.limits.ingestion_burst_size : "1000000", "1000000")
     limits_max_fetched_chunks_per_query         = try(var.mimir.limits.max_fetched_chunks_per_query != null ? var.mimir.limits.max_fetched_chunks_per_query : "5000000", "5000000")
-    limits_max_cache_freshness                  = try(var.mimir.limits.max_cache_freshness != null ? var.mimir.limits.max_cache_freshness : "12h", "12h")
+    limits_max_cache_freshness                  = try(var.mimir.limits.max_cache_freshness != null ? var.mimir.limits.max_cache_freshness : "1h", "1h")
     limits_max_outstanding_requests_per_tenant  = try(var.mimir.limits.max_outstanding_requests_per_tenant != null ? var.mimir.limits.max_outstanding_requests_per_tenant : "2000", "2000")
     compactor_replicas                          = try(var.mimir.compactor.replicas != null ? var.mimir.compactor.replicas : "2", "2")
     compactor_persistence_volume_enable         = try(var.mimir.compactor.persistence_volume.enable != null ? var.mimir.compactor.persistence_volume.enable : "true", "true")
-    compactor_persistence_volume_size           = try(var.mimir.compactor.persistence_volume.size != null ? var.mimir.compactor.persistence_volume.size : "20Gi", "20Gi")
+    compactor_persistence_volume_size           = try(var.mimir.compactor.persistence_volume.size != null ? var.mimir.compactor.persistence_volume.size : "50Gi", "50Gi")
     compactor_min_cpu                           = try(var.mimir.compactor.min_cpu != null ? var.mimir.compactor.min_cpu : "null", "null")
     compactor_min_memory                        = try(var.mimir.compactor.min_memory != null ? var.mimir.compactor.min_memory : "null", "null")
     compactor_max_cpu                           = try(var.mimir.compactor.max_cpu != null ? var.mimir.compactor.max_cpu : "null", "null")
@@ -85,6 +86,18 @@ data "template_file" "mimir_template" {
     distributor_min_cpu                         = try(var.mimir.distributor.min_cpu != null ? var.mimir.distributor.min_cpu : "null", "null")
     distributor_max_memory                      = try(var.mimir.distributor.max_memory != null ? var.mimir.distributor.max_memory : "null", "null")
     distributor_max_cpu                         = try(var.mimir.distributor.max_cpu != null ? var.mimir.distributor.max_cpu : "null", "null")
+    chunks_cache_enabled                        = try(var.mimir.caches.chunks.enabled != null ? var.mimir.caches.chunks.enabled : "true", "true")
+    chunks_cache_replicas                       = try(var.mimir.caches.chunks.replicas != null ? var.mimir.caches.chunks.replicas : 1, 1)
+    chunks_cache_max_item_memory                = try(var.mimir.caches.chunks.max_item_memory != null ? var.mimir.caches.chunks.max_item_memory : 8, 8)
+    chunks_cache_connection_limit               = try(var.mimir.caches.chunks.connection_limit != null ? var.mimir.caches.chunks.connection_limit : 16384, 16384)
+    index_cache_enabled                         = try(var.mimir.caches.index.enabled != null ? var.mimir.caches.index.enabled : "true", "true")
+    index_cache_replicas                        = try(var.mimir.caches.index.replicas != null ? var.mimir.caches.index.replicas : 1, 1)
+    index_cache_max_item_memory                 = try(var.mimir.caches.index.max_item_memory != null ? var.mimir.caches.index.max_item_memory : 8, 8)
+    index_cache_connection_limit                = try(var.mimir.caches.index.connection_limit != null ? var.mimir.caches.index.connection_limit : 16384, 16384)
+    metadata_cache_enabled                      = try(var.mimir.caches.metadata.enabled != null ? var.mimir.caches.metadata.enabled : "true", "true")
+    metadata_cache_replicas                     = try(var.mimir.caches.metadata.replicas != null ? var.mimir.caches.metadata.replicas : 1, 1)
+    metadata_cache_max_item_memory              = try(var.mimir.caches.metadata.max_item_memory != null ? var.mimir.caches.metadata.max_item_memory : 8, 8)
+    metadata_cache_connection_limit             = try(var.mimir.caches.metadata.connection_limit != null ? var.mimir.caches.metadata.connection_limit : 16384, 16384)
   }
 }
 

--- a/observability/gcp/templates/mimir-values.yaml
+++ b/observability/gcp/templates/mimir-values.yaml
@@ -19,13 +19,39 @@ mimir:
         bucket_name: "${data_bucket_name}"
       bucket_store:
         sync_dir: "/data"
+        {{- if index .Values "chunks-cache" "enabled" }}
+        chunks_cache:
+          backend: memcached
+          memcached:
+            addresses: {{ include "mimir.chunksCacheAddress" . }}
+            max_item_size: {{ mul (index .Values "chunks-cache").maxItemMemory 1024 1024 }}
+            timeout: 750ms
+            max_idle_connections: 150
+        {{- end }}
+        {{- if index .Values "index-cache" "enabled" }}
+        index_cache:
+          backend: memcached
+          memcached:
+            addresses: {{ include "mimir.indexCacheAddress" . }}
+            max_item_size: {{ mul (index .Values "index-cache").maxItemMemory 1024 1024 }}
+            timeout: 750ms
+            max_idle_connections: 150
+        {{- end }}
+        {{- if index .Values "metadata-cache" "enabled" }}
+        metadata_cache:
+          backend: memcached
+          memcached:
+            addresses: {{ include "mimir.metadataCacheAddress" . }}
+            max_item_size: {{ mul (index .Values "metadata-cache").maxItemMemory 1024 1024 }}
+            max_idle_connections: 150
+        {{- end }}
       tsdb:
         dir: "/data"
-        retention_period: 6h
-        block_ranges_period: ["2h", "12h", "24h"]
+        head_compaction_interval: 15m
     compactor:
       data_dir: "/data"
       compaction_interval: 5m
+      deletion_delay: 1h
     frontend:
       scheduler_address: mimir-query-scheduler.mimir.svc:9095
       split_queries_by_interval: 15m
@@ -37,6 +63,14 @@ mimir:
       max_outstanding_requests_per_tenant: ${limits_max_outstanding_requests_per_tenant}
     ruler:
       rule_path: /data
+      {{- if index .Values "metadata-cache" "enabled" }}
+    ruler_storage:
+      cache:
+        backend: memcached
+        memcached:
+          addresses: {{ include "mimir.metadataCacheAddress" . }}
+          max_item_size: {{ mul (index .Values "metadata-cache").maxItemMemory 1024 1024 }}
+      {{- end }}
     runtime_config:
       file: /var/{{ include "mimir.name" . }}/runtime.yaml
     store_gateway:
@@ -45,6 +79,24 @@ mimir:
           prefix: multi-zone/
           store: memberlist
         replication_factor: ${store_gateway_replication_factor}
+
+chunks-cache:
+  enabled:  {{ .Values.chunks_cache_enabled  }}
+  replicas: {{ .Values.chunks_cache_replicas }}
+  maxItemMemory: {{ .Values.chunks_cache_max_item_memory }}
+  connectionLimit: {{ .Values.chunks_cache_connection_limit }}
+
+index-cache:
+  enabled:  {{ .Values.index_cache_enabled  }}
+  replicas: {{ .Values.index_cache_replicas }}
+  maxItemMemory: {{ .Values.index_cache_max_item_memory }}
+  connectionLimit: {{ .Values.index_cache_connection_limit }}
+
+metadata-cache:
+  enabled:  {{ .Values.metadata_cache_enabled  }}
+  replicas: {{ .Values.metadata_cache_replicas }}
+  maxItemMemory: {{ .Values.metadata_cache_max_item_memory }}
+  connectionLimit: {{ .Values.metadata_cache_connection_limit }}
 
 nginx:
   enabled: false

--- a/observability/gcp/vars.tf
+++ b/observability/gcp/vars.tf
@@ -374,5 +374,26 @@ variable "mimir" {
       max_cpu            = optional(string)
       max_memory         = optional(string)
     }))
+    caches = optional(object({
+      chunks = optional(object({
+        enabled           = optional(bool)
+        replicas          = optional(number)
+        max_item_memory   = optional(number)
+        connection_limit  = optional(number)
+      }))
+      index = optional(object({
+        enabled           = optional(bool)
+        replicas          = optional(number)
+        max_item_memory   = optional(number)
+        connection_limit  = optional(number)
+      }))
+      metadata = optional(object({
+        enabled           = optional(bool)
+        replicas          = optional(number)
+        max_item_memory   = optional(number)
+        connection_limit  = optional(number)
+      }))
+    }))
+
   })
 }


### PR DESCRIPTION
Added caching for Mimir (metadata-cache, index-cache, chunks-cache) in GCP to improve performance.
Tuned configs like head_compaction_interval (15m), deletion_delay (1h), and adjusted some default values.
Improved memory handling to prevent ingester crashes and optimise metric queries.
These changes enhance stability and query responsiveness.