### PR TITLE
Restrict service account access to specific namespace using RoleBinding and remove cluster-wide IAM role

### DIFF
--- a/k8s/gcp/namespace/main.tf
+++ b/k8s/gcp/namespace/main.tf
@@ -17,7 +17,6 @@ locals {
 }
 
 resource "kubernetes_namespace" "app_environments" {
-
   metadata {
     name = var.namespace
   }
@@ -79,18 +78,23 @@ resource "google_secret_manager_secret_version" "namespace_svc_acc" {
   depends_on     = [google_secret_manager_secret.namespace_svc_acc]
 }
 
-resource "google_project_iam_member" "namespace_svc_acc_cluster" {
-  for_each    = local.gar_name_map
-  project     = var.provider_id
-  role        = "roles/container.clusterViewer"
-  member      = "serviceAccount:${google_service_account.service_deployment_svc_acc[each.key].email}"
+resource "google_project_iam_custom_role" "minimal_gke_access" {
+  role_id    = "minimalGkeAccess"
+  title      = "Minimal GKE Access Role"
+  description = "Minimal IAM permissions to access GKE clusters without full namespace access"
+  project    = var.provider_id
+
+  permissions = [
+    "container.clusters.get",
+    "container.clusters.list"
+  ]
 }
 
-resource "google_project_iam_member" "namespace_svc_acc_container" {
-  for_each    = local.gar_name_map
-  project     = var.provider_id
-  role        = "roles/container.developer"
-  member      = "serviceAccount:${google_service_account.service_deployment_svc_acc[each.key].email}"
+resource "google_project_iam_member" "namespace_svc_acc_custom" {
+  for_each = local.gar_name_map
+  project  = var.provider_id
+  role     = "projects/${var.provider_id}/roles/${google_project_iam_custom_role.minimal_gke_access.role_id}"
+  member   = "serviceAccount:${google_service_account.service_deployment_svc_acc[each.key].email}"
 }
 
 resource "google_artifact_registry_repository_iam_member" "artifact_member" {

--- a/k8s/gcp/namespace/main.tf
+++ b/k8s/gcp/namespace/main.tf
@@ -78,25 +78,6 @@ resource "google_secret_manager_secret_version" "namespace_svc_acc" {
   depends_on     = [google_secret_manager_secret.namespace_svc_acc]
 }
 
-resource "google_project_iam_custom_role" "minimal_gke_access" {
-  role_id    = "minimalGkeAccess"
-  title      = "Minimal GKE Access Role"
-  description = "Minimal IAM permissions to access GKE clusters without full namespace access"
-  project    = var.provider_id
-
-  permissions = [
-    "container.clusters.get",
-    "container.clusters.list"
-  ]
-}
-
-resource "google_project_iam_member" "namespace_svc_acc_custom" {
-  for_each = local.gar_name_map
-  project  = var.provider_id
-  role     = "projects/${var.provider_id}/roles/${google_project_iam_custom_role.minimal_gke_access.role_id}"
-  member   = "serviceAccount:${google_service_account.service_deployment_svc_acc[each.key].email}"
-}
-
 resource "google_artifact_registry_repository_iam_member" "artifact_member" {
   for_each   = local.gar_name_map
   provider   = google.artifact-registry

--- a/k8s/gcp/namespace/rbac.tf
+++ b/k8s/gcp/namespace/rbac.tf
@@ -90,3 +90,24 @@ resource "kubernetes_role_binding" "namespace_admin" {
     }
   }
 }
+
+resource "kubernetes_role_binding" "service_deployment_edit" {
+  for_each = google_service_account.service_deployment_svc_acc
+
+  metadata {
+    name      = "${each.value.display_name}-edit-binding"
+    namespace = kubernetes_namespace.app_environments.metadata[0].name
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "edit"
+  }
+
+  subject {
+    kind      = "User"
+    name      = each.value.email
+    api_group = "rbac.authorization.k8s.io"
+  }
+}

--- a/k8s/gcp/namespace/rbac.tf
+++ b/k8s/gcp/namespace/rbac.tf
@@ -91,7 +91,7 @@ resource "kubernetes_role_binding" "namespace_admin" {
   }
 }
 
-resource "kubernetes_role_binding" "service_deployment_edit" {
+resource "kubernetes_role_binding" "service_account_namespace_editor" {
   for_each = google_service_account.service_deployment_svc_acc
 
   metadata {

--- a/k8s/gcp/namespace/rbac.tf
+++ b/k8s/gcp/namespace/rbac.tf
@@ -28,6 +28,17 @@ resource "google_project_iam_member" "namespace_cluster_get" {
   member   = strcontains(each.value, "iam.gserviceaccount.com") ?"serviceAccount:${each.value}":"user:${each.value}"
 }
 
+resource "google_project_iam_member" "namespace_svc_acc_custom" {
+  for_each = {
+    for key, acc in google_service_account.service_deployment_svc_acc :
+    key => acc.email
+  }
+
+  project = var.provider_id
+  role    = "projects/${var.provider_id}/roles/${google_project_iam_custom_role.namespace_cluster_get_role.role_id}"
+  member  = "serviceAccount:${each.value}"
+}
+
 resource "kubernetes_role_binding" "namespace_editor" {
   count = length(coalesce(var.user_access.editors,[])) > 0 ? 1 : 0
   metadata {


### PR DESCRIPTION
Solved the issue helm-chart/237 ([GCP service's service-account Permission too broad](https://github.com/zopdev/helm-charts/issues/237))