### PR TITLE
Release v0.5.3

### DIFF
--- a/sql/gcp-sql/main.tf
+++ b/sql/gcp-sql/main.tf
@@ -57,6 +57,7 @@ resource "google_sql_database_instance" "postgres_sql_db" {
 
   settings {
     tier              = var.machine_type
+    edition           = var.sql_edition
     activation_policy = var.activation_policy
     disk_size         = var.disk_size
     disk_type         = var.disk_type
@@ -91,6 +92,7 @@ resource "google_sql_database_instance" "sql_db" {
 
   settings {
     tier              = var.machine_type
+    edition           = var.sql_edition
     activation_policy = var.activation_policy
     disk_size         = var.disk_size
     disk_type         = var.disk_type
@@ -148,6 +150,7 @@ resource "google_sql_database_instance" "sql_db_replica" {
 
   settings {
     tier              = var.machine_type
+    edition           = var.sql_edition
     activation_policy = var.activation_policy
     disk_type         = var.disk_type
     availability_type = "ZONAL"

--- a/sql/gcp-sql/vars.tf
+++ b/sql/gcp-sql/vars.tf
@@ -179,3 +179,9 @@ variable "multi_ds" {
   type        = bool
   default     = false
 }
+
+variable "sql_edition" {
+  description = "Cloud SQL edition. Defaults to ENTERPRISE which matches GCP's auto-assigned default for MySQL 5.6/5.7/8.0 and current Postgres versions; set to ENTERPRISE_PLUS for newer instances that need it. Declaring this here prevents drift on every terraform apply."
+  type        = string
+  default     = "ENTERPRISE"
+}


### PR DESCRIPTION
## What's Changed

### ⚒️ Fixes
- Fix `edition` drift in `gcp-sql` by setting it explicitly via a new `sql_edition` variable (default `ENTERPRISE`).