### PR TITLE
chore: bump zop-helm service chart to v0.0.32

### DIFF
--- a/zop-helm/service/main.tf
+++ b/zop-helm/service/main.tf
@@ -25,7 +25,7 @@ resource "helm_release" "service_helm"{
   name        = var.name
   namespace   = var.namespace
   repository  = "https://helm.zop.dev"
-  version     = "v0.0.29"
+  version     = "v0.0.32"
   chart       = "service"
   reuse_values = true
   max_history  = var.max_history


### PR DESCRIPTION
## Description

Bumps the `service` Helm chart pinned in the **`zop-helm/service`** module from `v0.0.29` to **`v0.0.32`** — the latest released version on `helm.zop.dev`.

```diff
-  version     = "v0.0.29"
+  version     = "v0.0.32"
   chart       = "service"
```

Scope: limited to `zop-helm/service/main.tf` only. Other modules that also reference `chart = "service"` (e.g. `kops-kube/*`, `zop-system/*`) are intentionally left unchanged.

## Type of Change
- [x] Chore (dependency/version bump)

## Notes
`v0.0.32` confirmed as the latest published `service` version in the live Helm repo index (`https://helm.zop.dev/index.yaml`).